### PR TITLE
hwservicemanager.rc: LD_PRELOAD the libselinux_stub.so

### DIFF
--- a/hwservicemanager.rc
+++ b/hwservicemanager.rc
@@ -1,4 +1,5 @@
 service hwservicemanager /system/bin/hwservicemanager
+    setenv LD_PRELOAD /system/lib64/libselinux_stubs.so
     user system
     disabled
     group system readproc


### PR DESCRIPTION
So that the calls for SELinux will work correctly.

Based on the device specific patches from Mer:
https://github.com/mer-hybris/droid-config-sony-nile/blob/7573a05c60974c95fe62bbcae681754e9c600af7/sparse/usr/libexec/droid-hybris/system/etc/init/hwservicemanager.rc#L4

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>